### PR TITLE
Automatically require-self-ref in every test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,10 @@
   "dependencies": {
     "aws-sdk": "^2.185.0",
     "bunyan": "^1.8.12"
+  },
+  "ava": {
+    "require": [
+      "require-self-ref"
+    ]
   }
 }

--- a/test/unit/lambda-aws-sts-caller-identity.test.ts
+++ b/test/unit/lambda-aws-sts-caller-identity.test.ts
@@ -6,7 +6,6 @@
  * AWS credentials, we create a mock for `aws-sdk` and use `proxyquire`
  * to replace the actual `aws-sdk` our mock;
  */
-import 'require-self-ref';
 import test from 'ava';
 import * as proxyquire from 'proxyquire';
 import invokeLambdaHandler from './util/invokeLambdaHandler';

--- a/test/unit/lambda-func1.test.ts
+++ b/test/unit/lambda-func1.test.ts
@@ -1,4 +1,3 @@
-import 'require-self-ref';
 import test from 'ava';
 import { handler as func1Handler } from '~/src/lambdas/func1';
 import invokeLambdaHandler from './util/invokeLambdaHandler';

--- a/test/unit/lambda-func2.test.ts
+++ b/test/unit/lambda-func2.test.ts
@@ -1,4 +1,3 @@
-import 'require-self-ref';
 import test from 'ava';
 import { handler as func2Handler } from '~/src/lambdas/func2';
 import invokeLambdaHandler from './util/invokeLambdaHandler';

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -1,4 +1,3 @@
-import 'require-self-ref';
 import test from 'ava';
 import * as util from '~/src/util';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,9 +44,9 @@
   dependencies:
     arrify "^1.0.1"
 
-"@types/aws-lambda@^0.0.27":
-  version "0.0.27"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-0.0.27.tgz#11bba7b856a6ba3f0c7b679956371e6315cd029c"
+"@types/aws-lambda@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-0.0.31.tgz#174d763bd801bc9106eaf40263fd78d8c300d950"
 
 "@types/bunyan@^1.8.4":
   version "1.8.4"


### PR DESCRIPTION
Just a small quality of life improvement. This change will allow for `require-self-ref` to be automatically loaded when running tests, this way developers won't have to manually import the module in every test file.